### PR TITLE
* fix of reader handle large files with few lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,26 @@
-# Created by https://www.toptal.com/developers/gitignore/api/java,intellij+all
-# Edit at https://www.toptal.com/developers/gitignore?templates=java,intellij+all
+# Created by https://www.toptal.com/developers/gitignore/api/maven
+# Edit at https://www.toptal.com/developers/gitignore?templates=maven
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# End of https://www.toptal.com/developers/gitignore/api/maven
 
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Start
 After packaging launch as standar .jar file with path to the file as an argument.
 
-Example: `java -jar codeassignment-0.0.1-SNAPSHOT.jar "C:\_Work\files\large.in"`
+Example: 
+
+    `java -jar codeassignment-0.0.1-SNAPSHOT.jar "C:\_Work\files\large.in"`
+
+Example with memory limit to 32m: 
+
+        `java -jar -Xmx32m codeassignment-0.0.1-SNAPSHOT.jar  "C:\Users\ondra\Downloads\f\small.in"`
 # Result
 When application ends without error, you can see paths to generated files in the console output.
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>annotations</artifactId>
             <version>13.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M8</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -101,6 +107,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.8</version>
                 <configuration>
                     <excludes>
                         <exclude>
@@ -109,11 +116,14 @@
                         </exclude>
                     </excludes>
                     <executable>true</executable>
-
-                    <jvmArguments>
-                        -Dfile.encoding=UTF8
-                        -Xmx32m
-                    </jvmArguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M8</version>
+                <configuration>
+                    <argLine>-Xmx32M</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/cz/ondrabilek/codeassignment/config/CmdLauncher.java
+++ b/src/main/java/cz/ondrabilek/codeassignment/config/CmdLauncher.java
@@ -9,6 +9,9 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -26,6 +29,8 @@ public class CmdLauncher {
             return;
         }
 
+        logHeapSize();
+
         String filePath = arguments.getSourceArgs()[0];
         log.info("File path passed: {}", filePath);
 
@@ -35,6 +40,11 @@ public class CmdLauncher {
         } catch (Exception e) {
             log.error("Process ended with error: {}", e.getLocalizedMessage());
         }
+    }
+
+    private void logHeapSize() {
+        log.info("Heap size: ~{} MB", BigDecimal.valueOf(Runtime.getRuntime().maxMemory())
+                .divide(BigDecimal.valueOf(1000000), RoundingMode.HALF_UP));
     }
 
 

--- a/src/test/java/cz/ondrabilek/codeassignment/FileTest.java
+++ b/src/test/java/cz/ondrabilek/codeassignment/FileTest.java
@@ -18,6 +18,10 @@ public abstract class FileTest {
         return getPath("files/tiny.in");
     }
 
+    protected Path getHugeOneLineFile() throws IOException {
+        return getPath("files/large_oneline.in");
+    }
+
     protected Path getSmallFile() throws IOException {
         return getPath("files/small.in");
     }

--- a/src/test/java/cz/ondrabilek/codeassignment/config/CmdLauncherTest.java
+++ b/src/test/java/cz/ondrabilek/codeassignment/config/CmdLauncherTest.java
@@ -1,0 +1,65 @@
+package cz.ondrabilek.codeassignment.config;
+
+import cz.ondrabilek.codeassignment.generator.CsvGenerator;
+import cz.ondrabilek.codeassignment.generator.XmlGenerator;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.ApplicationArguments;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CmdLauncherTest {
+
+    @Mock
+    private ApplicationArguments arguments;
+    @Mock
+    private XmlGenerator xmlGenerator;
+    @Mock
+    private CsvGenerator csvGenerator;
+    @InjectMocks
+    private CmdLauncher cmdLauncher;
+
+    @Captor
+    private ArgumentCaptor<String> strCaptor;
+
+    @Test
+    @SneakyThrows
+    void happyPath() {
+        when(arguments.getSourceArgs()).thenReturn(new String[]{"filePath"});
+
+        cmdLauncher.run();
+
+        verify(xmlGenerator, times(1)).parseAndOutput(strCaptor.capture());
+        verify(csvGenerator, times(1)).parseAndOutput(strCaptor.capture());
+        assertTrue(strCaptor.getAllValues().stream().allMatch(v -> StringUtils.equals("filePath", v)));
+    }
+
+    @Test
+    @SneakyThrows
+    void noArgumentGiven() {
+        when(arguments.getSourceArgs()).thenReturn(new String[0]);
+
+        cmdLauncher.run();
+
+        verify(xmlGenerator, never()).parseAndOutput(any());
+        verify(csvGenerator, never()).parseAndOutput(any());
+    }
+
+    @Test
+    @SneakyThrows
+    void appDoesNotCrash() {
+        when(arguments.getSourceArgs()).thenReturn(new String[]{"filePath"});
+        when(xmlGenerator.parseAndOutput(any())).thenThrow(new NullPointerException("Oh no!"));
+
+        cmdLauncher.run();
+    }
+}

--- a/src/test/java/cz/ondrabilek/codeassignment/generator/CsvGeneratorIntegrationTest.java
+++ b/src/test/java/cz/ondrabilek/codeassignment/generator/CsvGeneratorIntegrationTest.java
@@ -1,0 +1,40 @@
+package cz.ondrabilek.codeassignment.generator;
+
+import cz.ondrabilek.codeassignment.FileTest;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+@Disabled
+class CsvGeneratorIntegrationTest extends FileTest {
+
+    @Autowired
+    private CsvGenerator generator;
+
+    @AfterEach
+    @SneakyThrows
+    void tearDown() {
+        deleteAllCreatedFiles();
+    }
+
+    @Test
+    @SneakyThrows
+    void happyPath_hugeOneLine() {
+        log.info("Heap size: {}", Runtime.getRuntime().maxMemory());
+        generator.parseAndOutput(getHugeOneLineFile().toString());
+    }
+
+    @Test
+    @SneakyThrows
+    void small() {
+        log.info("Heap size: {}", Runtime.getRuntime().maxMemory());
+        generator.parseAndOutput(getSmallFile().toString());
+    }
+
+}

--- a/src/test/java/cz/ondrabilek/codeassignment/generator/CsvGeneratorTest.java
+++ b/src/test/java/cz/ondrabilek/codeassignment/generator/CsvGeneratorTest.java
@@ -56,7 +56,7 @@ class CsvGeneratorTest extends FileTest {
     @Test
     @SneakyThrows
     void nullFile() {
-        assertThrows(NullPointerException.class, () -> generator.parseAndOutput(null), "inputFilePath is NULL");
+        assertThrows(IllegalArgumentException.class, () -> generator.parseAndOutput(null), "inputFilePath is NULL");
     }
 
     @Test

--- a/src/test/java/cz/ondrabilek/codeassignment/generator/XmlGeneratorTest.java
+++ b/src/test/java/cz/ondrabilek/codeassignment/generator/XmlGeneratorTest.java
@@ -56,7 +56,7 @@ class XmlGeneratorTest extends FileTest {
     @Test
     @SneakyThrows
     void nullFile() {
-        assertThrows(NullPointerException.class, () -> generator.parseAndOutput(null), "inputFilePath is NULL");
+        assertThrows(IllegalArgumentException.class, () -> generator.parseAndOutput(null), "inputFilePath is NULL");
     }
 
     @Test


### PR DESCRIPTION
* (disabled) integration tests, just to make it easier
* tests for CmdLauncher
* for the sake of this excercise heap size is limited in pom.xml for tests
* CmdLauncher outputs max heap size to the console, to make testing simpler